### PR TITLE
Improved OCR, more gas types support and api for finding gas stations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN pip install \
     tesseract \
     pytesseract \
     Pillow
+    geopy
 
 # Copy the python files to the image
 COPY ./app/api.py /home/apiuser/app/api.py

--- a/app/api.py
+++ b/app/api.py
@@ -3,6 +3,8 @@ Dutch Gas prices API
 """
 from fastapi import FastAPI, Query
 from gas_prices import gas_prices
+from gas_stations import gas_stations
+from enum import Enum
 
 app = FastAPI(
     title="Dutch Gas prices API",
@@ -10,6 +12,12 @@ app = FastAPI(
     version="1.0",
 )
 
+class FuelName(str, Enum):
+    euro95 = "euro95"
+    euro98 = "euro98"
+    diesel = "diesel"
+    lpg = "autogas"
+#    cng = "aardgas"
 
 @app.get("/")
 async def root():
@@ -30,4 +38,15 @@ async def api_gas_prices(station_id: str = Query(None, \
     Query the gas prices from a station
     """
     result = gas_prices(station_id)
+    return result
+
+@app.get("/api/v1/gas_stations/{fuel}",
+         summary="Query fuel specific gas stations in a radius",
+         description="Returns stations from directlease.nl based on latitude, longitude and a radius",
+         )
+async def api_gas_stations(fuel: FuelName, longitude: float, latitude: float, radius: int = Query(default=5, gt=0, le=15)):
+    """
+    Query fuel specific gas stations in a radius
+    """
+    result = gas_stations(fuel,longitude,latitude,radius)
     return result

--- a/app/gas_prices.py
+++ b/app/gas_prices.py
@@ -6,8 +6,9 @@ import os
 import time
 from io import BytesIO
 import re
-from PIL import Image
+from PIL import Image, ImageEnhance, ImageDraw
 import requests
+import math
 import pytesseract
 from fake_headers import Headers
 
@@ -15,7 +16,7 @@ from fake_headers import Headers
 # Something like lru_cache would be nice but has no time expiring support, so custom json storage
 CACHE_TIME = 3600
 
-def gas_prices(station_id):
+def gas_prices(station_id, fuel = None):
     """
     Main Dutch Gas prices API Function
     """
@@ -29,17 +30,19 @@ def gas_prices(station_id):
         try:
             word_list = None
             for i, line in enumerate(lines):
-                if search_value in line:
-                    word_list = line.split()
-                    break
-            if word_list is None and search_value == 'Euro 95':
-                for i, line in enumerate(lines):
-                    if 'Euro95' in line:
+                for value in search_value:
+                    if value in line.lower():
                         word_list = line.split()
                         break
-            else:
+                if word_list:
+                    break
+
+
+            if word_list:
                 return_value1 = word_list[-1].replace(',', '.')
                 return_value2 = re.sub("[^0-9,.]", "", return_value1)
+                if len(return_value2) == 5: #the superscript digit should not be incorporated
+                    return_value2 = return_value2[:4]
                 return_value = float(return_value2)
                 if return_value > 2:
                     return_value = float(return_value2[0] + '.' + return_value2[1])
@@ -47,7 +50,7 @@ def gas_prices(station_id):
                     pass
         except Exception as exception_info:
             print(f'_search_value failed: {exception_info}')
-                
+
         return return_value
 
 
@@ -60,26 +63,39 @@ def gas_prices(station_id):
         response = requests.get(url, headers=headers)
         if response.status_code == 200:
             img = Image.open(BytesIO(response.content))
-            img.save(f'cache/{station_id}.png')
-            ocr_result = pytesseract.image_to_string(img)
+            img2 = img.convert('L') #assign other var, convert does not work otherwise
+            width, height = img2.size
+            newsize = (width*2, height*2)
+            img2 = img2.resize(newsize) #resize for better ocr
+            draw = ImageDraw.Draw(img2)
+            draw.rectangle((((width*2) - 180), 100, (width*2), 0), fill=240) #replace logo, prevent OCR from reading text
+            img2.save(f'cache/{station_id}.png')
+            ocr_result = pytesseract.image_to_string(img2, config='--psm 6 --oem 3') #configure tesseract explicit
             ocr_lines = ocr_result.split("\n")
 
-            benzine_prijs = _search_value(ocr_lines, 'Euro 95')
-            diesel_prijs = _search_value(ocr_lines, 'Diesel')
+            #lowercase definition of fuels to search
+            euro95_prijs = _search_value(ocr_lines, ['euro 95','euro95','(e10)'])
+            diesel_prijs = _search_value(ocr_lines, ['diesel','(b7)'])
+            lpg_prijs = _search_value(ocr_lines, ['lpg'])
+            euro98_prijs = _search_value(ocr_lines, ['euro 98','euro98','e5'])
 
-            if (benzine_prijs is None) or (diesel_prijs is None):
+            if (euro95_prijs is None) or (diesel_prijs is None):
                 data = {
                     'station_id': station_id,
-                    'benzine_prijs': benzine_prijs,
-                    'diesel_prijs' : diesel_prijs,
+                    'euro95': euro95_prijs,
+                    'euro98': euro98_prijs,
+                    'diesel' : diesel_prijs,
+                    'lpg' : lpg_prijs,
                     'ocr_station' : ocr_lines[0],
                     'status' : 'Station exists?'
                     }
             else:
                 data = {
                     'station_id': station_id,
-                    'benzine_prijs': benzine_prijs,
-                    'diesel_prijs' : diesel_prijs,
+                    'euro95': euro95_prijs,
+                    'euro98': euro98_prijs,
+                    'diesel' : diesel_prijs,
+                    'lpg' : lpg_prijs,
                     'ocr_station' : ocr_lines[0],
                     'status' : 'Ok'
                     }
@@ -94,8 +110,10 @@ def gas_prices(station_id):
             print(f'Error: Response text: {response.text}')
             data = {
                 'station_id': None,
-                'benzine_prijs': None,
-                'diesel_prijs' : None,
+                'euro95': None,
+                'euro98': None,
+                'diesel' : None,
+                'lpg' : None,
                 'ocr_station' : None,
                 'status' : f'{response.status_code}'
                 }
@@ -129,6 +147,17 @@ def gas_prices(station_id):
     else:
         print('New request')
         return_value = _write_stationdata(station_id)
+
+    #Only return the fuel that was requested
+    if fuel:
+        newdata = {
+                'station_id': return_value['station_id'],
+                'prijs': return_value[fuel],
+                'ocr_station' : return_value['ocr_station'],
+                'status' : return_value['status']
+                }
+        return_value = newdata
+    print (return_value)
     return return_value
 
 if __name__ == '__main__':

--- a/app/gas_stations.py
+++ b/app/gas_stations.py
@@ -1,0 +1,115 @@
+"""
+Dutch Gas prices API Module
+"""
+import json
+import os
+import time
+from io import BytesIO
+import re
+from PIL import Image
+import requests
+import pytesseract
+from fake_headers import Headers
+from geopy import distance
+from gas_prices import gas_prices
+
+# Settings
+# Something like lru_cache would be nice but has no time expiring support, so custom json storage
+CACHE_TIME = 86400 #24h, could be longer, stations don't come and go very often
+
+def gas_stations(fuel,longitude,latitude,radius):
+    """
+    Main Dutch Gas stations API Function
+    """
+
+    url = f'https://tankservice.app-it-up.com/Tankservice/v1/places?fmt=web&fuel={fuel}'
+
+    def is_location_in_radius(lat, lon, station_lat, station_lon, km):
+        center_point = [{'lat': lat, 'lng': lon}]
+        test_point = [{'lat': station_lat, 'lng': station_lon}]
+        radius = float(km) # in kilometer
+
+        center_point_tuple = tuple(center_point[0].values())
+        test_point_tuple = tuple(test_point[0].values())
+
+        dis = distance.distance(center_point_tuple, test_point_tuple).km
+
+        if dis <= radius:
+            return True # location is within radius
+        else:
+            return False
+
+    def _write_stationdata():
+        """
+        Query the api and cache the results to a json file
+        """
+        headers = Headers(headers=True).generate()
+
+        response = requests.get(url, headers=headers)
+        if response.status_code == 200:
+            data = response.json()
+
+            with open('cache/' + f'{fuel}.json', 'w') as outfile:
+                    json.dump(data, outfile)
+        else:
+            print(f'Error: statuscode: {response.status_code}')
+            print(f'Error: Used header: {headers}')
+            ip_addr = requests.get('https://api.ipify.org').text
+            print(f'Error: Used IP: {ip_addr}')
+            print(f'Error: Response text: {response.text}')
+            data = {}
+        return data
+
+    def _read_stationdata():
+        """
+        Get the cached json file
+        """
+        with open('cache/' + f'{fuel}.json') as json_file:
+            data = json.load(json_file)
+            return data
+
+    def _file_age(fuel):
+        """
+        Calculate the json file age
+        """
+        try:
+            return time.time() - os.path.getmtime('cache/' + f'{fuel}.json')
+        except IOError:
+            return 99999999
+
+    # Main logic
+    age_of_file = _file_age(fuel)
+    print(age_of_file)
+    if age_of_file < CACHE_TIME:
+        print('Cache request')
+        stationdata = _read_stationdata()
+    else:
+        print('New request')
+        stationdata = _write_stationdata()
+
+    stations = []
+    for station in stationdata:
+        """
+        Loop through all stations and find if they are within radius
+        """
+        newstation = {}
+        newstation['brand'] = station['brand']
+        newstation['name'] = station['name']
+        station_lat = str(station['lat'])
+        newstation['latitude'] = float(station_lat[:2] + "." + station_lat[2:])#quick and dirty conversion of lat lon to float, should not be done this way
+        station_lon = str(station['lng'])
+        newstation['longitude'] = float(station_lon[:1] + "." + station_lon[1:])
+        newstation['fuel'] = fuel
+        return_value = is_location_in_radius(latitude, longitude, newstation['latitude'] , newstation['longitude'], radius)
+        if return_value == True:
+            gasprices = gas_prices(station['id'], fuel)
+            if gasprices['prijs']:
+                stations.append({**newstation, **gasprices})
+
+    return_value = {}
+    return_value['gas_stations'] = sorted(stations, key=lambda x: x['prijs'], reverse=False) #sort on prijs, cheapest first
+    print(return_value)
+    return return_value
+
+if __name__ == '__main__':
+    gas_stations('lpg','4.89','52.37','5') # Executed when this file is triggered directly


### PR DESCRIPTION
This PR adds the gas types euro98 and lpg to the gas_prices.py output. To accommodate this, a breaking change is created for the output. benzine_prijs and diesel_prijs no longer exists in the output. The assumption is that every gas station sells Diesel and Euro95, so they are both still to be expected to be present.

OCR is improved by converting the image to greyscale and by enlarging the image. This resulted in a better OCR result, especially for LPG. There is also a logo replacement (draw rectangle) to prevent tesseract to read text in a logo. The way the fuel types are "read" by the code is, what i think, also improved. I could not really figure out why Euro95 was explicitly defined in gas_prices.py, so i hope i provided a solution that fits that bill.

Last but not least gas_stations.py is added so you now can search for a gas station in the vicinity. For Home Assistant, a rest api would look like this.
`http://server:5035/api/v1/gas_stations/euro95?longitude={{ state_attr("zone.home", "longitude") }}&latitude={{ state_attr("zone.home", "latitude") }}
`

Please let me know what you think. If you think improvements are needed, i would happily add those.